### PR TITLE
Choose the oldest Xorg process

### DIFF
--- a/touchpad-state
+++ b/touchpad-state
@@ -8,7 +8,7 @@ usage () { echo "${0##*/} [--off] [--on] — set the touchpad state" ; }
 
 # X.org server process name
 xorgprc=Xorg
-xorgpid=$(pgrep -x $xorgprc)
+xorgpid=$(pgrep -o -x $xorgprc)
 
 # X.org server test if running
 if [ ! "$xorgpid" ]; then


### PR DESCRIPTION
In my case it isn't working without because Xorg starts other Xorg process which in turn makes the variable not evaluate correctly.

This patch should make touchpad-state choose the older process which ensures that there is just one process chosen.
